### PR TITLE
Remove outdated links from docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@ steampipe plugin install guardrails
 
 ### Credentials
 
-Installing the latest guardrails plugin will create a config file (`~/.steampipe/config/guardrails.spc`) with a single connection named `guardrails`. By default, Steampipe will use your [Turbot Guardrails profiles and credentials](https://turbot.com/v5/docs/reference/cli/installation#setup-your-turbot-credentials) exactly the same as the Turbot Guardrails CLI and Turbot Guardrails Terraform provider. In many cases, no extra configuration is required to use Steampipe.
+Installing the latest guardrails plugin will create a config file (`~/.steampipe/config/guardrails.spc`) with a single connection named `guardrails`. By default, Steampipe will use your [Turbot Guardrails profiles and credentials](https://turbot.com/guardrails/docs/reference/cli/installation#set-up-your-turbot-guardrails-credentials) exactly the same as the Turbot Guardrails CLI and Turbot Guardrails Terraform provider. In many cases, no extra configuration is required to use Steampipe.
 
 ```hcl
 connection "guardrails" {

--- a/docs/tables/guardrails_notification.md
+++ b/docs/tables/guardrails_notification.md
@@ -23,7 +23,7 @@ When querying this table, we recommend using at least one of these columns (usua
 - `create_timestamp`
 - `filter`
 
-For more information on how to construct a `filter`, please see [Notifications examples](https://turbot.com/v5/docs/reference/filter/notifications#examples).
+For more information on how to construct a `filter`, please see [Notifications examples](https://turbot.com/guardrails/docs/reference/filter/notifications#examples).
 
 ## Examples
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
