### PR TITLE
Adding `object` column to guardrails_notification and guardrails_resource

### DIFF
--- a/apiClient/resource.go
+++ b/apiClient/resource.go
@@ -180,6 +180,7 @@ func (client *Client) AssignResourceResults(responseData interface{}, properties
 	var resource Resource
 	// initialise map
 	resource.Data = make(map[string]interface{})
+
 	// convert turbot property to structure
 	if err := mapstructure.Decode(responseData.(map[string]interface{})["turbot"], &resource.Turbot); err != nil {
 		return nil, err
@@ -190,6 +191,9 @@ func (client *Client) AssignResourceResults(responseData interface{}, properties
 	}
 	// convert object property to structure
 	if err := mapstructure.Decode(responseData.(map[string]interface{})["data"], &resource.Data); err != nil {
+		return nil, err
+	}
+	if err := mapstructure.Decode(responseData.(map[string]interface{})["object"], &resource.Object); err != nil {
 		return nil, err
 	}
 	// write properties into a map

--- a/apiClient/types.go
+++ b/apiClient/types.go
@@ -32,6 +32,7 @@ type ResourceResponse struct {
 type Resource struct {
 	Turbot   TurbotResourceMetadata
 	Data     map[string]interface{}
+	Object   map[string]interface{}
 	Metadata map[string]interface{}
 	Type     struct {
 		Uri string
@@ -52,6 +53,7 @@ type ResourceSchema struct {
 type ReadSerializableResourceResponse struct {
 	Resource struct {
 		Data   map[string]interface{}
+		Object map[string]interface{}
 		Turbot map[string]interface{}
 		Tags   map[string]string
 		Akas   []string

--- a/guardrails/table_guardrails_notification.go
+++ b/guardrails/table_guardrails_notification.go
@@ -64,6 +64,7 @@ func tableGuardrailsNotification(ctx context.Context) *plugin.Table {
 			{Name: "resource_type_uri", Type: proto.ColumnType_STRING, Transform: transform.FromField("Resource.Type.URI"), Description: "URI of the resource type for this notification."},
 			{Name: "resource_type_trunk_title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Resource.Type.Trunk.Title"), Description: "Title of the resource type hierarchy from the root down to this resource."},
 			{Name: "resource_data", Type: proto.ColumnType_JSON, Transform: transform.FromField("Resource.Data"), Description: "The data for this resource"},
+			{Name: "resource_object", Type: proto.ColumnType_JSON, Transform: transform.FromField("Resource.Object"), Description: "More detailed and extensive resource data"},
 			{Name: "resource_akas", Type: proto.ColumnType_JSON, Transform: transform.FromField("Resource.Turbot.Akas"), Description: "The globally-unique akas for this resource."},
 			{Name: "resource_parent_id", Type: proto.ColumnType_INT, Transform: transform.FromField("Resource.Turbot.ParentID").NullIfZero(), Description: "The id of the parent resource of this resource."},
 			{Name: "resource_path", Type: proto.ColumnType_STRING, Transform: transform.FromField("Resource.Turbot.Path"), Description: "The string of resource ids separated by \".\" from root down to this resource."},
@@ -128,7 +129,6 @@ const (
 		query notificationList($filter: [String!], $next_token: String) {
 			notifications(filter: $filter, paging: $next_token) {
 				items {
-
 					icon
 					message
 					notificationType
@@ -162,6 +162,7 @@ const (
 
 					resource {
 						data
+						object
 						metadata
 						trunk {
 							title
@@ -279,6 +280,7 @@ const (
 				message
 				notificationType
 				data
+
 				actor {
 					identity {
 						trunk {
@@ -307,6 +309,7 @@ const (
 				}
 				resource {
 					data
+					object
 					metadata
 					trunk {
 						title
@@ -420,6 +423,7 @@ func listNotification(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 		return nil, err
 	}
 
+	//build the Quals/Filters for the query
 	filters := []string{}
 	quals := d.EqualsQuals
 	allQuals := d.Quals
@@ -548,7 +552,7 @@ func getNotification(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	return result.Notification, nil
 }
 
-//// TRANFORM FUNCTION
+//// TRANSFORM FUNCTION
 
 // formatPolicyValue:: Policy value can be a string, hcl or a json.
 // It will transform the raw value from api into a string if a hcl or json

--- a/guardrails/table_guardrails_resource.go
+++ b/guardrails/table_guardrails_resource.go
@@ -34,6 +34,7 @@ func tableGuardrailsResource(ctx context.Context) *plugin.Table {
 			// Other columns
 			{Name: "create_timestamp", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("Turbot.CreateTimestamp"), Description: "When the resource was first discovered by Turbot. (It may have been created earlier.)"},
 			{Name: "data", Type: proto.ColumnType_JSON, Description: "Resource data."},
+			{Name: "object", Type: proto.ColumnType_JSON, Description: "Extended Resource data."},
 			{Name: "filter", Type: proto.ColumnType_STRING, Transform: transform.FromQual("filter"), Description: "Filter used for this resource list."},
 			{Name: "metadata", Type: proto.ColumnType_JSON, Description: "Resource custom metadata."},
 			{Name: "parent_id", Type: proto.ColumnType_INT, Transform: transform.FromField("Turbot.ParentID"), Description: "ID for the parent of this resource. For the Turbot root resource this is null."},
@@ -54,6 +55,7 @@ query resourceList($filter: [String!], $next_token: String) {
 	resources(filter: $filter, paging: $next_token) {
 		items {
 			data
+			object
 			metadata
 			trunk {
 				title

--- a/guardrails/types.go
+++ b/guardrails/types.go
@@ -26,6 +26,7 @@ type Resource struct {
 		Items []GuardrailsIDObject
 	}
 	Data     map[string]interface{}
+	Object   map[string]interface{}
 	Metadata map[string]interface{}
 	Trunk    struct {
 		Title string
@@ -446,6 +447,7 @@ type Notification struct {
 
 	Resource struct {
 		Data     interface{}
+		Object   interface{}
 		Metadata interface{}
 		Type     struct {
 			URI    string


### PR DESCRIPTION
- For guardrails_notification, references to `resource.data` always shows the resource as it is at the time of the query.  References to `resource.object` shows the resource as it was at the time of the event.  Resource.object is required to show changes in resource state over time.
- Added resource.object to guardrails_resource because it provides access to the `terraform` data set.  This addition allows users to query for terraform ownership and id for a given resource.
- I added resource.object for Notification and Resource to preserve the existing `data` column but also provide access to the more detailed `object` info.  Also, Notification and Resource share the `Resource` struct. If adding for one, may as well add for the other too.

# Example query results


```
select resource_data, resource_object, resource_object #>> '{turbot,terraform}' as terraform
    from guardrails_notification
where filter = 'resourceId:"{resource_id}" notificationType:resource level:self';
```
Should return not-null values for the resource_data, resource_object, and terraform columns.

```
select data, object, object #>> '{turbot,terraform}' as terraform
    from guardrails_resource
where filter = 'resourceId:"{resource_id}" notificationType:resource level:self';
```

Should return not-null values for the data, object and terraform columns.  Terraform will return '{}' if there is no TF configuration data.

</details>
