### PR TITLE
Added support to bypass SSL/TLS certificate verification while querying the tables

### DIFF
--- a/apiClient/client.go
+++ b/apiClient/client.go
@@ -29,7 +29,7 @@ type Client struct {
 	Graphql   *graphql.Client
 }
 
-func CreateClient(config ClientConfig) (*Client, error) {
+func CreateClient(config ClientConfig, opts ...graphql.ClientOption) (*Client, error) {
 	// if accessKeyId and secretAccessKey were not directly specified (either via provider parameters or environment variables)
 	// look for a credentials file
 
@@ -40,7 +40,7 @@ func CreateClient(config ClientConfig) (*Client, error) {
 	return &Client{
 		AccessKey: credentials.AccessKey,
 		SecretKey: credentials.SecretKey,
-		Graphql:   graphql.NewClient(credentials.Workspace),
+		Graphql:   graphql.NewClient(credentials.Workspace, opts...),
 	}, nil
 }
 

--- a/config/guardrails.spc
+++ b/config/guardrails.spc
@@ -15,4 +15,7 @@ connection "guardrails" {
   # workspace  = "https://turbot-acme.cloud.turbot.com/"
   # access_key = "c8e2c2ed-1ca8-429b-b369-010e3cf75aac"
   # secret_key = "a3d8385d-47f7-40c5-a90c-bfdf5b43c8dd"
+
+  # Optional: Enable or disable SSL/TLS certificate verification. Defaults to false.
+  # insecure_skip_verify = false
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ For users with multiple workspaces and more complex authentication use cases, he
 
 ### Credentials via key pair
 
-The Turbot Guardrails plugin allows you to set static credentials with the `access_key`, `secret_key`, `workspace` and `insecure_skip_verify` arguments in any connection profile.
+The Turbot Guardrails plugin allows you to set static credentials with the `access_key`, `secret_key`, `workspace`, and `insecure_skip_verify` arguments in any connection profile.
 
 ```hcl
 connection "guardrails" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ For users with multiple workspaces and more complex authentication use cases, he
 
 ### Credentials via key pair
 
-The Turbot Guardrails plugin allows you to set static credentials with the `access_key`, `secret_key`, and `workspace` arguments in any connection profile.
+The Turbot Guardrails plugin allows you to set static credentials with the `access_key`, `secret_key`, `workspace` and `insecure_skip_verify` arguments in any connection profile.
 
 ```hcl
 connection "guardrails" {
@@ -80,6 +80,7 @@ connection "guardrails" {
   access_key = "c8e2c2ed-1ca8-429b-b369-010e3cf75aac"
   secret_key = "a3d8385d-47f7-40c5-a90c-bfdf5b43c8dd"
   workspace  = "https://turbot-acme.cloud.turbot.com/"
+  insecure_skip_verify = false
 }
 ```
 
@@ -110,10 +111,8 @@ export TURBOT_ACCESS_KEY=86835f29-1c88-46d9-b6ce-cbe5016842d3
 export TURBOT_WORKSPACE=https://turbot-acme.cloud.turbot.com
 ```
 
-You can also change the default profile to a named profile with the TURBOT_PROFILE  environment variable:
+You can also change the default profile to a named profile with the TURBOT_PROFILE environment variable:
 
 ```sh
 export TURBOT_PROFILE=turbot-acme
 ```
-
-

--- a/guardrails/connection_config.go
+++ b/guardrails/connection_config.go
@@ -5,10 +5,11 @@ import (
 )
 
 type guardrailsConfig struct {
-	Profile   *string `hcl:"profile"`
-	AccessKey *string `hcl:"access_key"`
-	SecretKey *string `hcl:"secret_key"`
-	Workspace *string `hcl:"workspace"`
+	Profile            *string `hcl:"profile"`
+	AccessKey          *string `hcl:"access_key"`
+	SecretKey          *string `hcl:"secret_key"`
+	Workspace          *string `hcl:"workspace"`
+	InsecureSkipVerify *bool   `hcl:"insecure_skip_verify,optional"`
 }
 
 func ConfigInstance() interface{} {


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from guardrails_control limit 5
+-----------------+-------+--------+---------+-----------------+----------------------------------------------------------------------+--------------------------+-----------------+-----------------------------------------------------+---------------------------+------->
| id              | state | reason | details | resource_id     | resource_trunk_title                                                 | control_type_trunk_title | control_type_id | control_type_uri                                    | create_timestamp          | filter>
+-----------------+-------+--------+---------+-----------------+----------------------------------------------------------------------+--------------------------+-----------------+-----------------------------------------------------+---------------------------+------->
| 326469291363785 | ok    |        | <null>  | 326469291345347 | Turbot > @turbot/azure-storage > Logging                             | Turbot > Type Installed  | 173722764488486 | tmod:@turbot/turbot#/control/types/controlInstalled | 2024-07-13T10:57:46+05:30 | <null>>
| 326735264983588 | ok    |        | <null>  | 326735264972319 | Turbot > @turbot/gcp-sql > Update Encryption in Transit              | Turbot > Type Installed  | 173722764488486 | tmod:@turbot/turbot#/control/types/controlInstalled | 2024-07-16T11:06:46+05:30 | <null>>
| 326469291782639 | ok    |        | <null>  | 326469291775466 | Turbot > @turbot/azure-storage > Update Storage Account Blob Logging | Turbot > Type Installed  | 173722764488486 | tmod:@turbot/turbot#/control/types/controlInstalled | 2024-07-13T10:57:46+05:30 | <null>>
| 326735264706076 | ok    |        | <null>  | 326735264676374 | Turbot > @turbot/gcp-sql > Encryption In Transit                     | Turbot > Type Installed  | 173722764488486 | tmod:@turbot/turbot#/control/types/controlInstalled | 2024-07-16T11:06:46+05:30 | <null>>
| 326735264614931 | ok    |        | <null>  | 326735264487949 | Turbot > @turbot/gcp-sql > Encryption In Transit                     | Turbot > Type Installed  | 173722764488486 | tmod:@turbot/turbot#/control/types/controlInstalled | 2024-07-16T11:06:46+05:30 | <null>>
+-----------------+-------+--------+---------+-----------------+----------------------------------------------------------------------+--------------------------+-----------------+-----------------------------------------------------+---------------------------+------->

Time: 1.6s. Rows returned: 5. Rows fetched: 5. Hydrate calls: 80.

Scans:
  1) guardrails_control.guardrails: Time: 1.5s. Fetched: 5. Hydrates: 80. Limit: 5.
```
</details>
