### PR TITLE
Handle Not Found errors gracefully during resource list queries

### DIFF
--- a/guardrails/table_guardrails_resource.go
+++ b/guardrails/table_guardrails_resource.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/turbot/steampipe-plugin-guardrails/errors"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -148,6 +149,12 @@ func listResource(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 		err = conn.DoRequest(queryResourceList, variables, result)
 		if err != nil {
 			plugin.Logger(ctx).Error("guardrails_resource.listResource", "query_error", err)
+			// If a resource is deleted mid-query, the API returns a Not Found error.
+			// Log the warning and continue rather than failing the entire query.
+			if errors.NotFoundError(err) {
+				plugin.Logger(ctx).Warn("guardrails_resource.listResource", "resource_not_found", "A resource may have been deleted mid-query, skipping page", "error", err)
+				break
+			}
 			return nil, err
 		}
 		for _, r := range result.Resources.Items {


### PR DESCRIPTION
## Summary
- When a resource is deleted mid-query, the Guardrails API returns a Not Found error that previously caused the entire `guardrails_resource` list query to fail fatally
- Now we detect Not Found errors during pagination, log a warning, and return partial results instead of crashing
- Follows the same pattern already used in `guardrails_notification` and `guardrails_tag` tables

Closes #102

## Test plan
- [ ] Run `select * from guardrails_resource` against a workspace with active resource discovery/deletion
- [ ] Verify query completes with partial results when a resource is deleted mid-query
- [ ] Verify non-Not Found errors (e.g. auth failures, 500s) still propagate as fatal errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)